### PR TITLE
Add support for PRs from forked repos

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,5 +17,5 @@ inputs:
     description: "Only request reviews without commenting (defaults to 'false')"
     required: false
 runs:
-  using: node12
+  using: node20
   main: dist/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,6 +1,314 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
+/***/ 9881:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+const core = __nccwpck_require__(127);
+const github = __nccwpck_require__(8067);
+
+const { debug, formatLineNumbers } = __nccwpck_require__(7670);
+const excludedFiles = ["go.mod", "go.sum", "vendor/"];
+
+class Variables {
+  static _instance = null;
+  _variables = {};
+
+  constructor() {
+    if (Variables._instance) {
+      return Variables._instance;
+    }
+
+    const token = core.getInput("github-token", { required: true });
+
+    const quietInput = core.getInput("quiet", { required: false }) || "false";
+    const quiet = ["true", "yes", "on"].includes(quietInput.toLowerCase());
+
+    const pullRequest = github.context.payload.pull_request;
+
+    this._variables = {
+      mainBranch: core.getInput("main-branch", { required: false }) || "main",
+      octokit: github.getOctokit(token),
+      pullRequestAuthor: pullRequest.user.login,
+      pullRequestBranch: pullRequest.head.ref,
+      pullRequestNumber: pullRequest.number,
+      quiet,
+      repo: github.context.repo,
+      token,
+      isFork: pullRequest.head.repo.fork,
+      headRepo: pullRequest.head.repo.full_name,
+    };
+
+    Variables._instance = this;
+  }
+
+  set(name, value) {
+    this._variables[name] = value;
+  }
+
+  get(name) {
+    return this._variables[name];
+  }
+}
+
+async function getOpenPullRequests() {
+  const variables = new Variables();
+  const octokit = variables.get("octokit");
+  const repo = variables.get("repo");
+
+  try {
+    const allPullRequests = []
+    let page = 1;
+    while (true) {
+      const { data: pullRequests } = await octokit.rest.pulls.list({
+        owner: repo.owner,
+        repo: repo.repo,
+        state: "open",
+        per_page: 100,
+        page: page,
+      });
+
+      if (pullRequests.length > 0) {
+        allPullRequests.push(...pullRequests);
+        page++;
+      } else {
+        break
+      }
+    }
+
+    const openPullRequests = []
+
+    for (const pr of allPullRequests) {
+      if (pr.draft) {
+        continue
+      }
+
+      openPullRequests.push({
+        number: pr.number,
+        author: pr.user.login,
+        branch: pr.head.ref,
+        title: pr.title,
+        reviewers: await getAllReviewers(pr.number),
+        isFork: pr.head.repo.fork,
+        repo: pr.head.repo.full_name,
+      })
+    }
+
+    return openPullRequests;
+  } catch (error) {
+    console.error(`Error fetching open pull requests: ${error.message}`);
+    throw error;
+  }
+}
+
+async function getChangedFiles(anyPullRequestNumber) {
+  const variables = new Variables();
+  const octokit = variables.get("octokit");
+  const repo = variables.get("repo");
+
+  const allFiles = []
+  let page = 1;
+  while (true) {
+    const { data: files } = await octokit.rest.pulls.listFiles({
+      owner: repo.owner,
+      repo: repo.repo,
+      pull_number: anyPullRequestNumber,
+      per_page: 100,
+      page: page,
+    });
+
+    if (files.length > 0) {
+      allFiles.push(...files);
+      page++;
+    } else {
+      break
+    }
+  }
+
+  return allFiles.map((file) => file.filename).filter((file) => !ignoreFile(file));
+}
+
+function ignoreFile(filename) {
+    for (const excluded of excludedFiles) {
+      if (filename.includes(excluded)) {
+        return true
+      }
+    }
+    return false
+}
+
+async function requestReviews(conflictArray) {
+  const variables = new Variables();
+  const octokit = variables.get("octokit");
+  const pullRequestAuthor = variables.get("pullRequestAuthor");
+  const pullRequestNumber = variables.get("pullRequestNumber");
+  const repo = variables.get("repo");
+
+  try {
+    const existing_reviewers = await getAllReviewers(pullRequestNumber)
+    const reviewers = [
+      ...new Set(
+        conflictArray
+          .map((conflict) => conflict.author)
+          .filter((author) => author !== pullRequestAuthor && !existing_reviewers.has(author))
+      ),
+    ];
+
+    if (reviewers.length > 0) {
+      debug(`Requesting reviews from ${reviewers.join(", ")}`);
+
+      await octokit.rest.pulls.requestReviewers({
+        owner: repo.owner,
+        repo: repo.repo,
+        pull_number: pullRequestNumber,
+        reviewers: reviewers,
+      });
+    } else {
+      debug(`No new reviews to request.`)
+    }
+
+    return reviewers.length
+  } catch (error) {
+    console.error(`Error requesting reviews: ${error.message}`);
+    throw error;
+  }
+}
+
+async function requestReviewsInConflictingPRs(conflictArray) {
+  const variables = new Variables();
+  const octokit = variables.get("octokit");
+  const pullRequestAuthor = variables.get("pullRequestAuthor");
+  const repo = variables.get("repo");
+
+  let requestedReviews = 0;
+  try {
+    for (const conflict of conflictArray) {
+      if (conflict.author !== pullRequestAuthor && !conflict.reviewers.has(pullRequestAuthor)) {
+        debug(
+          `Requesting review from ${pullRequestAuthor} in #${conflict.number}`
+        );
+
+        await octokit.rest.pulls.requestReviewers({
+          owner: repo.owner,
+          repo: repo.repo,
+          pull_number: conflict.number,
+          reviewers: [pullRequestAuthor],
+        });
+        requestedReviews++;
+      }
+    }
+
+    return requestedReviews;
+  } catch (error) {
+    console.error(
+      `Error requesting reviews in conflicting PRs: ${error.message}`
+    );
+    throw error;
+  }
+}
+
+// This function gets all reviewers on the conflicting pull requests.
+// The reviewers include requested reviewers and those who have left a review.
+async function getAllReviewers(pr_number) {
+  const variables = new Variables();
+  const octokit = variables.get("octokit");
+  const repo = variables.get("repo");
+
+  const { data: reviews } = await octokit.rest.pulls.listReviews({
+    owner: repo.owner,
+    repo: repo.repo,
+    pull_number: pr_number,
+  });
+
+  const { data: requested_reviewers } = await octokit.rest.pulls.listRequestedReviewers({
+    owner: repo.owner,
+    repo: repo.repo,
+    pull_number: pr_number,
+  });
+
+  const viewed_reviewers = reviews.map((r) => r.user.login)
+  const req_reviewers = requested_reviewers.users.map((r) => r.login)
+
+  return new Set (viewed_reviewers.concat(req_reviewers))
+}
+
+async function createConflictComment(conflictArray) {
+  const variables = new Variables();
+  const octokit = variables.get("octokit");
+  const pullRequestNumber = variables.get("pullRequestNumber");
+  const repo = variables.get("repo");
+
+  try {
+    let totalFilesWithConflicts = 0;
+    let conflictMessage = "";
+
+    for (const data of conflictArray) {
+      totalFilesWithConflicts += Object.keys(data.conflictData).length;
+      conflictMessage += `<details>\n`;
+      conflictMessage += `  <summary>${data.title} (#${data.number}) by @${data.author}</summary>\n`;
+
+      for (const [fileName, lineNumbers] of Object.entries(data.conflictData)) {
+        const allFiles = []
+        let page = 1;
+        while (true) {
+          const { data: files } = await octokit.rest.pulls.listFiles({
+            owner: repo.owner,
+            repo: repo.repo,
+            pull_number: data.number,
+            per_page: 100,
+            page: page,
+          });
+
+          if (files.length > 0) {
+            allFiles.push(...files);
+            page++;
+          } else {
+            break
+          }
+        }
+
+        const blobUrl = allFiles.find(
+          (file) => file.filename === fileName
+        ).blob_url;
+
+        conflictMessage += `\u00A0\u00A0\u00A0 <a href="${blobUrl}">${fileName}</a> \u2015 ${formatLineNumbers(
+          lineNumbers
+        )}<br />`;
+      }
+
+      conflictMessage += `</details>\n\n`;
+    }
+
+    const prs = conflictArray.length === 1 ? "PR" : "PRs";
+    const files = totalFilesWithConflicts === 1 ? "file" : "files";
+
+    conflictMessage =
+      `Conflicts detected in ${totalFilesWithConflicts} ${files} across ${conflictArray.length} ${prs}\n\n` +
+      conflictMessage;
+
+    await octokit.rest.issues.createComment({
+      owner: repo.owner,
+      repo: repo.repo,
+      issue_number: pullRequestNumber,
+      body: conflictMessage,
+    });
+  } catch (error) {
+    console.error(`Error creating conflict comment: ${error.message}`);
+    throw error;
+  }
+}
+
+module.exports = {
+  Variables,
+  getOpenPullRequests,
+  getChangedFiles,
+  requestReviews,
+  requestReviewsInConflictingPRs,
+  createConflictComment
+};
+
+/***/ }),
+
 /***/ 7670:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
@@ -9880,53 +10188,19 @@ const github = __nccwpck_require__(8067);
 const { execSync } = __nccwpck_require__(2081);
 const readFileSync = (__nccwpck_require__(7147).readFileSync);
 
-const { debug, formatLineNumbers } = __nccwpck_require__(7670);
-const excludedFiles = ["go.mod", "go.sum", "vendor/"];
-
-class Variables {
-  static _instance = null;
-  _variables = {};
-
-  constructor() {
-    if (Variables._instance) {
-      return Variables._instance;
-    }
-
-    const token = core.getInput("github-token", { required: true });
-
-    const quietInput = core.getInput("quiet", { required: false }) || "false";
-    const quiet = ["true", "yes", "on"].includes(quietInput.toLowerCase());
-
-    const pullRequest = github.context.payload.pull_request;
-
-    this._variables = {
-      mainBranch: core.getInput("main-branch", { required: false }) || "main",
-      octokit: github.getOctokit(token),
-      pullRequestAuthor: pullRequest.user.login,
-      pullRequestBranch: pullRequest.head.ref,
-      pullRequestNumber: pullRequest.number,
-      quiet,
-      repo: github.context.repo,
-      token,
-      isFork: pullRequest.head.repo.fork,
-      headRepo: pullRequest.head.repo.full_name,
-    };
-
-    Variables._instance = this;
-  }
-
-  set(name, value) {
-    this._variables[name] = value;
-  }
-
-  get(name) {
-    return this._variables[name];
-  }
-}
+const { debug } = __nccwpck_require__(7670);
+const {
+  Variables,
+  getOpenPullRequests,
+  getChangedFiles,
+  requestReviews,
+  requestReviewsInConflictingPRs,
+  createConflictComment,
+} = __nccwpck_require__(9881);
 
 async function main() {
   if (github.context.payload.pull_request.draft) {
-    debug(`Not running any checks because this pull request is a draft.`)
+    debug(`Not running any checks because this pull request is a draft`)
     return
   }
 
@@ -10024,68 +10298,6 @@ async function getConflictArrayData() {
   return conflictArray;
 }
 
-function cleanup() {
-  try {
-    const pullRequest = github.context.payload.pull_request;
-
-    execSync(`git update-ref -d refs/remotes/origin/tmp_${pullRequest.number}`);
-  } catch (e) {
-    console.error(`Error during cleanup: ${error.message}`);
-    throw error;
-  }
-}
-
-async function getOpenPullRequests() {
-  const variables = new Variables();
-  const octokit = variables.get("octokit");
-  const repo = variables.get("repo");
-
-  try {
-    const allPullRequests = []
-    let page = 1;
-    while (true) {
-      const { data: pullRequests } = await octokit.rest.pulls.list({
-        owner: repo.owner,
-        repo: repo.repo,
-        state: "open",
-        per_page: 100,
-        page: page,
-      });
-
-      if (pullRequests.length > 0) {
-        allPullRequests.push(...pullRequests);
-        page++;
-      } else {
-        break
-      }
-    }
-
-    const openPullRequests = []
-
-    for (const pr of allPullRequests) {
-      if (pr.draft) {
-        continue
-      }
-
-      openPullRequests.push({
-        number: pr.number,
-        author: pr.user.login,
-        branch: pr.head.ref,
-        title: pr.title,
-        reviewers: await getAllReviewers(pr.number),
-        isFork: pr.head.repo.fork,
-        repo: pr.head.repo.full_name,
-      })
-    }
-
-    return openPullRequests;
-  } catch (error) {
-    console.error(`Error fetching open pull requests: ${error.message}`);
-    throw error;
-  }
-}
-
-
 async function checkForConflicts(otherPullRequest) {
   const variables = new Variables();
   const pullRequestBranch = variables.get("pullRequestBranch");
@@ -10111,33 +10323,6 @@ async function checkForConflicts(otherPullRequest) {
   const conflictData = await attemptMerge(otherPullRequest);
 
   return conflictData;
-}
-
-async function getChangedFiles(anyPullRequestNumber) {
-  const variables = new Variables();
-  const octokit = variables.get("octokit");
-  const repo = variables.get("repo");
-
-  const allFiles = []
-  let page = 1;
-  while (true) {
-    const { data: files } = await octokit.rest.pulls.listFiles({
-      owner: repo.owner,
-      repo: repo.repo,
-      pull_number: anyPullRequestNumber,
-      per_page: 100,
-      page: page,
-    });
-
-    if (files.length > 0) {
-      allFiles.push(...files);
-      page++;
-    } else {
-      break
-    }
-  }
-
-  return allFiles.map((file) => file.filename).filter((file) => !ignoreFile(file));
 }
 
 async function attemptMerge(otherPullRequest) {
@@ -10273,174 +10458,15 @@ function extractConflictingLineNumbers(otherPullRequestBranch, filePath) {
   return conflictLines;
 }
 
-async function createConflictComment(conflictArray) {
-  const variables = new Variables();
-  const octokit = variables.get("octokit");
-  const pullRequestNumber = variables.get("pullRequestNumber");
-  const repo = variables.get("repo");
-
+function cleanup() {
   try {
-    let totalFilesWithConflicts = 0;
-    let conflictMessage = "";
+    const pullRequest = github.context.payload.pull_request;
 
-    for (const data of conflictArray) {
-      totalFilesWithConflicts += Object.keys(data.conflictData).length;
-      conflictMessage += `<details>\n`;
-      conflictMessage += `  <summary>${data.title} (#${data.number}) by @${data.author}</summary>\n`;
-
-      for (const [fileName, lineNumbers] of Object.entries(data.conflictData)) {
-        const allFiles = []
-        let page = 1;
-        while (true) {
-          const { data: files } = await octokit.rest.pulls.listFiles({
-            owner: repo.owner,
-            repo: repo.repo,
-            pull_number: data.number,
-            per_page: 100,
-            page: page,
-          });
-
-          if (files.length > 0) {
-            allFiles.push(...files);
-            page++;
-          } else {
-            break
-          }
-        }
-
-        const blobUrl = allFiles.find(
-          (file) => file.filename === fileName
-        ).blob_url;
-
-        conflictMessage += `\u00A0\u00A0\u00A0 <a href="${blobUrl}">${fileName}</a> \u2015 ${formatLineNumbers(
-          lineNumbers
-        )}<br />`;
-      }
-
-      conflictMessage += `</details>\n\n`;
-    }
-
-    const prs = conflictArray.length === 1 ? "PR" : "PRs";
-    const files = totalFilesWithConflicts === 1 ? "file" : "files";
-
-    conflictMessage =
-      `Conflicts detected in ${totalFilesWithConflicts} ${files} across ${conflictArray.length} ${prs}\n\n` +
-      conflictMessage;
-
-    await octokit.rest.issues.createComment({
-      owner: repo.owner,
-      repo: repo.repo,
-      issue_number: pullRequestNumber,
-      body: conflictMessage,
-    });
-  } catch (error) {
-    console.error(`Error creating conflict comment: ${error.message}`);
+    execSync(`git update-ref -d refs/remotes/origin/tmp_${pullRequest.number}`);
+  } catch (e) {
+    console.error(`Error during cleanup: ${error.message}`);
     throw error;
   }
-}
-
-async function requestReviews(conflictArray) {
-  const variables = new Variables();
-  const octokit = variables.get("octokit");
-  const pullRequestAuthor = variables.get("pullRequestAuthor");
-  const pullRequestNumber = variables.get("pullRequestNumber");
-  const repo = variables.get("repo");
-
-  try {
-    const existing_reviewers = await getAllReviewers(pullRequestNumber)
-    const reviewers = [
-      ...new Set(
-        conflictArray
-          .map((conflict) => conflict.author)
-          .filter((author) => author !== pullRequestAuthor && !existing_reviewers.has(author))
-      ),
-    ];
-
-    if (reviewers.length > 0) {
-      debug(`Requesting reviews from ${reviewers.join(", ")}`);
-
-      await octokit.rest.pulls.requestReviewers({
-        owner: repo.owner,
-        repo: repo.repo,
-        pull_number: pullRequestNumber,
-        reviewers: reviewers,
-      });
-    } else {
-      debug(`No new reviews to request.`)
-    }
-
-    return reviewers.length
-  } catch (error) {
-    console.error(`Error requesting reviews: ${error.message}`);
-    throw error;
-  }
-}
-
-async function requestReviewsInConflictingPRs(conflictArray) {
-  const variables = new Variables();
-  const octokit = variables.get("octokit");
-  const pullRequestAuthor = variables.get("pullRequestAuthor");
-  const repo = variables.get("repo");
-
-  let requestedReviews = 0;
-  try {
-    for (const conflict of conflictArray) {
-      if (conflict.author !== pullRequestAuthor && !conflict.reviewers.has(pullRequestAuthor)) {
-        debug(
-          `Requesting review from ${pullRequestAuthor} in #${conflict.number}`
-        );
-
-        await octokit.rest.pulls.requestReviewers({
-          owner: repo.owner,
-          repo: repo.repo,
-          pull_number: conflict.number,
-          reviewers: [pullRequestAuthor],
-        });
-        requestedReviews++;
-      }
-    }
-
-    return requestedReviews;
-  } catch (error) {
-    console.error(
-      `Error requesting reviews in conflicting PRs: ${error.message}`
-    );
-    throw error;
-  }
-}
-
-// This function gets all reviewers on the conflicting pull requests.
-// The reviewers include requested reviewers and those who have left a review.
-async function getAllReviewers(pr_number) {
-  const variables = new Variables();
-  const octokit = variables.get("octokit");
-  const repo = variables.get("repo");
-
-  const { data: reviews } = await octokit.rest.pulls.listReviews({
-    owner: repo.owner,
-    repo: repo.repo,
-    pull_number: pr_number,
-  });
-
-  const { data: requested_reviewers } = await octokit.rest.pulls.listRequestedReviewers({
-    owner: repo.owner,
-    repo: repo.repo,
-    pull_number: pr_number,
-  });
-
-  const viewed_reviewers = reviews.map((r) => r.user.login)
-  const req_reviewers = requested_reviewers.users.map((r) => r.login)
-
-  return new Set (viewed_reviewers.concat(req_reviewers))
-}
-
-function ignoreFile(filename) {
-    for (const excluded of excludedFiles) {
-      if (filename.includes(excluded)) {
-        return true
-      }
-    }
-    return false
 }
 
 main();

--- a/dist/index.js
+++ b/dist/index.js
@@ -9908,6 +9908,8 @@ class Variables {
       quiet,
       repo: github.context.repo,
       token,
+      isFork: pullRequest.head.repo.fork,
+      headRepo: pullRequest.head.repo.full_name,
     };
 
     Variables._instance = this;
@@ -9956,20 +9958,31 @@ async function setup() {
   const variables = new Variables();
   const mainBranch = variables.get("mainBranch");
   const pullRequestBranch = variables.get("pullRequestBranch");
+  const pullRequestAuthor = variables.get("pullRequestAuthor");
+  const headRepo = variables.get("headRepo"); 
 
   try {
-    // Configure Git with a dummy user identity
+    // Configure Git with a dummy user identity.
     execSync(`git config user.email "action@github.com"`);
     execSync(`git config user.name "GitHub Action"`);
 
     execSync(`git fetch origin ${mainBranch}:${mainBranch}`);
 
-    // Fetch PR branches into temporary refs
-    execSync(
-      `git fetch origin ${pullRequestBranch}:refs/remotes/origin/tmp_${pullRequestBranch}`
-    );
+    // Fetch PR branches into temporary refs.
+    if (variables.get("isFork")) {
+      execSync(
+        `git remote add ${pullRequestAuthor} https://github.com/${headRepo}.git`
+      );
+      execSync(
+        `git fetch ${pullRequestAuthor} ${pullRequestBranch}:refs/remotes/origin/tmp_${pullRequestBranch}`
+      );
+    } else {
+      execSync(
+        `git fetch origin ${pullRequestBranch}:refs/remotes/origin/tmp_${pullRequestBranch}`
+      );
+    } 
 
-    // Merge main into pull request branch in memory
+    // Merge main into pull request branch in memory.
     execSync(`git checkout refs/remotes/origin/tmp_${pullRequestBranch}`);
     execSync(`git merge ${mainBranch} --no-commit --no-ff`);
     execSync(`git reset --hard HEAD`);
@@ -9977,6 +9990,38 @@ async function setup() {
     console.error(`Error during setup: ${error.message}`);
     throw error;
   }
+}
+
+async function getConflictArrayData() {
+  const variables = new Variables();
+  const pullRequestNumber = variables.get("pullRequestNumber");
+
+  const openPullRequests = await getOpenPullRequests();
+  const otherPullRequests = openPullRequests.filter(
+    (pr) => pr.number !== pullRequestNumber
+  );
+
+  debug(
+    `Checking for conflicts against ${otherPullRequests.length} other pull requests`
+  );
+
+  const conflictArray = [];
+
+  for (const otherPullRequest of otherPullRequests) {
+    const conflictData = await checkForConflicts(otherPullRequest);
+
+    if (Object.keys(conflictData).length > 0) {
+      conflictArray.push({
+        author: otherPullRequest.author,
+        conflictData,
+        number: otherPullRequest.number,
+        title: otherPullRequest.title,
+        reviewers: otherPullRequest.reviewers,
+      });
+    } 
+  }
+
+  return conflictArray;
 }
 
 function cleanup() {
@@ -10028,6 +10073,8 @@ async function getOpenPullRequests() {
         branch: pr.head.ref,
         title: pr.title,
         reviewers: await getAllReviewers(pr.number),
+        isFork: pr.head.repo.fork,
+        repo: pr.head.repo.full_name,
       })
     }
 
@@ -10038,33 +10085,6 @@ async function getOpenPullRequests() {
   }
 }
 
-async function getConflictArrayData() {
-  const variables = new Variables();
-  const pullRequestNumber = variables.get("pullRequestNumber");
-
-  const openPullRequests = await getOpenPullRequests();
-  const otherPullRequests = openPullRequests.filter(
-    (pr) => pr.number !== pullRequestNumber
-  );
-
-  const conflictArray = [];
-
-  for (const otherPullRequest of otherPullRequests) {
-    const conflictData = await checkForConflicts(otherPullRequest);
-
-    if (Object.keys(conflictData).length > 0) {
-      conflictArray.push({
-        author: otherPullRequest.author,
-        conflictData,
-        number: otherPullRequest.number,
-        title: otherPullRequest.title,
-        reviewers: otherPullRequest.reviewers,
-      });
-    }
-  }
-
-  return conflictArray;
-}
 
 async function checkForConflicts(otherPullRequest) {
   const variables = new Variables();
@@ -10084,10 +10104,11 @@ async function checkForConflicts(otherPullRequest) {
   );
 
   if (!overlappingFiles.length) {
+    debug(`No overlapping files with #${otherPullRequest.branch}, will not attempt merge`)
     return [];
   }
 
-  const conflictData = await attemptMerge(otherPullRequest.branch);
+  const conflictData = await attemptMerge(otherPullRequest);
 
   return conflictData;
 }
@@ -10097,19 +10118,114 @@ async function getChangedFiles(anyPullRequestNumber) {
   const octokit = variables.get("octokit");
   const repo = variables.get("repo");
 
-  const { data: files } = await octokit.rest.pulls.listFiles({
-    owner: repo.owner,
-    repo: repo.repo,
-    pull_number: anyPullRequestNumber,
-  });
+  const allFiles = []
+  let page = 1;
+  while (true) {
+    const { data: files } = await octokit.rest.pulls.listFiles({
+      owner: repo.owner,
+      repo: repo.repo,
+      pull_number: anyPullRequestNumber,
+      per_page: 100,
+      page: page,
+    });
 
-  return files.map((file) => file.filename).filter((file) => !ignoreFile(file));
+    if (files.length > 0) {
+      allFiles.push(...files);
+      page++;
+    } else {
+      break
+    }
+  }
+
+  return allFiles.map((file) => file.filename).filter((file) => !ignoreFile(file));
+}
+
+async function attemptMerge(otherPullRequest) {
+  const variables = new Variables();
+  const mainBranch = variables.get("mainBranch");
+  const pullRequestBranch = variables.get("pullRequestBranch");
+  const quiet = variables.get("quiet");
+
+  const conflictData = {};
+
+  try {
+    debug(
+      `Attempting to merge #${otherPullRequest.branch} into #${pullRequestBranch}`
+    );
+
+    if (otherPullRequest.isFork) {
+      // This is in another try catch because we may have already fetched this fork.
+      try {
+        execSync(
+          `git remote add ${otherPullRequest.author} https://github.com/${otherPullRequest.repo}.git`
+        );
+      } catch(error) {
+        console.log(error)
+      }
+
+      execSync(
+        `git fetch ${otherPullRequest.author} ${otherPullRequest.branch}:refs/remotes/origin/tmp_${otherPullRequest.branch}`
+      );
+    } else {
+      execSync(
+        `git fetch origin ${otherPullRequest.branch}:refs/remotes/origin/tmp_${otherPullRequest.branch}`
+      );
+    }
+
+    // Merge main into other pull request in memory.
+    execSync(`git checkout refs/remotes/origin/tmp_${otherPullRequest.branch}`);
+    execSync(`git merge ${mainBranch} --no-commit --no-ff`);
+    execSync(`git reset --hard HEAD`);
+
+    try {
+      // Attempt to merge other pull request branch in memory without committing or fast-forwarding.
+      execSync(
+        `git merge refs/remotes/origin/tmp_${pullRequestBranch} --no-commit --no-ff`
+      );
+
+      debug(`${otherPullRequest.branch} merge successful. No conflicts found.`);
+    } catch (mergeError) {
+      const stdoutStr = mergeError.stdout.toString();
+      if (stdoutStr.includes("Automatic merge failed")) {
+        if (quiet) {
+          return {
+            0: "Extracting data is unnecessary if commenting is disabled.",
+          };
+        }
+
+        const output = execSync(
+          "git diff --name-only --diff-filter=U"
+        ).toString();
+        const conflictFileNames = output.split("\n").filter(Boolean);
+
+        for (const filename of conflictFileNames) {
+          debug(`Extracting conflicting line numbers for ${filename}`);
+          conflictData[filename] = extractConflictingLineNumbers(
+            otherPullRequest.branch,
+            filename
+          );
+        }
+      }
+    }
+  } catch (error) {
+    console.error(`Error during merge process: ${error.message}`);
+  } finally {
+    // Reset any changes.
+    execSync(`git reset --hard HEAD`);
+    // Cleanup by deleting temporary refs.
+    execSync(
+      `git update-ref -d refs/remotes/origin/tmp_${otherPullRequest.branch}`
+    );
+  }
+
+  return conflictData;
 }
 
 function extractConflictingLineNumbers(otherPullRequestBranch, filePath) {
   const fileContentWithoutConflicts = execSync(
-    `git show origin/${otherPullRequestBranch}:${filePath}`
+    `git show refs/remotes/origin/tmp_${otherPullRequestBranch}:${filePath}`
   ).toString();
+
   const linesFromNormalFile = fileContentWithoutConflicts.split("\n");
 
   const fileContentWithConflicts = readFileSync(filePath, "utf8");
@@ -10130,7 +10246,7 @@ function extractConflictingLineNumbers(otherPullRequestBranch, filePath) {
       inOursBlock = false;
       const startIndex = linesFromNormalFile.indexOf(oursBlock[0]);
       if (startIndex !== -1) {
-        // Verify that the block matches
+        // Verify that the block matches.
         const doesMatch = oursBlock.every(
           (ourLine, index) =>
             ourLine === linesFromNormalFile[startIndex + index]
@@ -10155,71 +10271,6 @@ function extractConflictingLineNumbers(otherPullRequestBranch, filePath) {
   }
 
   return conflictLines;
-}
-
-async function attemptMerge(otherPullRequestBranch) {
-  const variables = new Variables();
-  const mainBranch = variables.get("mainBranch");
-  const pullRequestBranch = variables.get("pullRequestBranch");
-  const quiet = variables.get("quiet");
-
-  const conflictData = {};
-
-  try {
-    debug(
-      `Attempting to merge #${otherPullRequestBranch} into #${pullRequestBranch}`
-    );
-
-    execSync(
-      `git fetch origin ${otherPullRequestBranch}:refs/remotes/origin/tmp_${otherPullRequestBranch}`
-    );
-
-    // Merge main into other pull request in memory
-    execSync(`git checkout refs/remotes/origin/tmp_${otherPullRequestBranch}`);
-    execSync(`git merge ${mainBranch} --no-commit --no-ff`);
-    execSync(`git reset --hard HEAD`);
-
-    try {
-      // Attempt to merge other pull request branch in memory without committing or fast-forwarding
-      execSync(
-        `git merge refs/remotes/origin/tmp_${pullRequestBranch} --no-commit --no-ff`
-      );
-
-      debug(`${otherPullRequestBranch} merge successful. No conflicts found.`);
-    } catch (mergeError) {
-      const stdoutStr = mergeError.stdout.toString();
-      if (stdoutStr.includes("Automatic merge failed")) {
-        if (quiet) {
-          return {
-            0: "Extracting data is unnecessary if commenting is disabled.",
-          };
-        }
-
-        const output = execSync(
-          "git diff --name-only --diff-filter=U"
-        ).toString();
-        const conflictFileNames = output.split("\n").filter(Boolean);
-
-        for (const filename of conflictFileNames) {
-          debug(`Extracting conflicting line numbers for ${filename}`);
-          conflictData[filename] = extractConflictingLineNumbers(
-            otherPullRequestBranch,
-            filename
-          );
-        }
-      }
-    }
-  } catch (error) {
-    console.error(`Error during merge process: ${error.message}`);
-  } finally {
-    execSync(`git reset --hard HEAD`); // Reset any changes
-    // Cleanup by deleting temporary refs
-    execSync(
-      `git update-ref -d refs/remotes/origin/tmp_${otherPullRequestBranch}`
-    );
-  }
-
-  return conflictData;
 }
 
 async function createConflictComment(conflictArray) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -36,7 +36,7 @@ class Variables {
       repo: github.context.repo,
       token,
       isFork: pullRequest.head.repo.fork,
-      headRepo: pullRequest.head.repo.full_name,
+      pullRequestHeadUrl: pullRequest.head.repo.clone_url,
     };
 
     Variables._instance = this;
@@ -90,7 +90,7 @@ async function getOpenPullRequests() {
         title: pr.title,
         reviewers: await getAllReviewers(pr.number),
         isFork: pr.head.repo.fork,
-        repo: pr.head.repo.full_name,
+        pullRequestHeadUrl: pr.head.repo.clone_url,
       })
     }
 
@@ -10233,31 +10233,35 @@ async function setup() {
   const mainBranch = variables.get("mainBranch");
   const pullRequestBranch = variables.get("pullRequestBranch");
   const pullRequestAuthor = variables.get("pullRequestAuthor");
-  const headRepo = variables.get("headRepo"); 
+  const pullRequestHeadUrl = variables.get("pullRequestHeadUrl"); 
 
   try {
     // Configure Git with a dummy user identity.
     execSync(`git config user.email "action@github.com"`);
     execSync(`git config user.name "GitHub Action"`);
 
+    debug(`Fetching branch: ${mainBranch}`);
+
     execSync(`git fetch origin ${mainBranch}:${mainBranch}`);
+
+    debug(`Fetching branch: ${pullRequestBranch}`);
 
     // Fetch PR branches into temporary refs.
     if (variables.get("isFork")) {
       execSync(
-        `git remote add ${pullRequestAuthor} https://github.com/${headRepo}.git`
+        `git remote add ${pullRequestAuthor} ${pullRequestHeadUrl}`
       );
       execSync(
-        `git fetch ${pullRequestAuthor} ${pullRequestBranch}:refs/remotes/origin/tmp_${pullRequestBranch}`
+        `git fetch ${pullRequestAuthor} ${pullRequestBranch}:refs/remotes/origin/conflictbot_tmp_${pullRequestBranch}`
       );
     } else {
       execSync(
-        `git fetch origin ${pullRequestBranch}:refs/remotes/origin/tmp_${pullRequestBranch}`
+        `git fetch origin ${pullRequestBranch}:refs/remotes/origin/conflictbot_tmp_${pullRequestBranch}`
       );
     } 
 
     // Merge main into pull request branch in memory.
-    execSync(`git checkout refs/remotes/origin/tmp_${pullRequestBranch}`);
+    execSync(`git checkout refs/remotes/origin/conflictbot_tmp_${pullRequestBranch}`);
     execSync(`git merge ${mainBranch} --no-commit --no-ff`);
     execSync(`git reset --hard HEAD`);
   } catch (error) {
@@ -10338,34 +10342,36 @@ async function attemptMerge(otherPullRequest) {
       `Attempting to merge #${otherPullRequest.branch} into #${pullRequestBranch}`
     );
 
+    debug(`Fetching branch: ${otherPullRequest.branch}`);
+
     if (otherPullRequest.isFork) {
-      // This is in another try catch because we may have already fetched this fork.
+      // This is in another try catch because we may have already added this remote.
       try {
         execSync(
-          `git remote add ${otherPullRequest.author} https://github.com/${otherPullRequest.repo}.git`
+          `git remote add ${otherPullRequest.author} ${otherPullRequest.pullRequestHeadUrl}`
         );
       } catch(error) {
         console.log(error)
       }
 
       execSync(
-        `git fetch ${otherPullRequest.author} ${otherPullRequest.branch}:refs/remotes/origin/tmp_${otherPullRequest.branch}`
+        `git fetch ${otherPullRequest.author} ${otherPullRequest.branch}:refs/remotes/origin/conflictbot_tmp_${otherPullRequest.branch}`
       );
     } else {
       execSync(
-        `git fetch origin ${otherPullRequest.branch}:refs/remotes/origin/tmp_${otherPullRequest.branch}`
+        `git fetch origin ${otherPullRequest.branch}:refs/remotes/origin/conflictbot_tmp_${otherPullRequest.branch}`
       );
     }
 
     // Merge main into other pull request in memory.
-    execSync(`git checkout refs/remotes/origin/tmp_${otherPullRequest.branch}`);
+    execSync(`git checkout refs/remotes/origin/conflictbot_tmp_${otherPullRequest.branch}`);
     execSync(`git merge ${mainBranch} --no-commit --no-ff`);
     execSync(`git reset --hard HEAD`);
 
     try {
       // Attempt to merge other pull request branch in memory without committing or fast-forwarding.
       execSync(
-        `git merge refs/remotes/origin/tmp_${pullRequestBranch} --no-commit --no-ff`
+        `git merge refs/remotes/origin/conflictbot_tmp_${pullRequestBranch} --no-commit --no-ff`
       );
 
       debug(`${otherPullRequest.branch} merge successful. No conflicts found.`);
@@ -10399,7 +10405,7 @@ async function attemptMerge(otherPullRequest) {
     execSync(`git reset --hard HEAD`);
     // Cleanup by deleting temporary refs.
     execSync(
-      `git update-ref -d refs/remotes/origin/tmp_${otherPullRequest.branch}`
+      `git update-ref -d refs/remotes/origin/conflictbot_tmp_${otherPullRequest.branch}`
     );
   }
 
@@ -10408,7 +10414,7 @@ async function attemptMerge(otherPullRequest) {
 
 function extractConflictingLineNumbers(otherPullRequestBranch, filePath) {
   const fileContentWithoutConflicts = execSync(
-    `git show refs/remotes/origin/tmp_${otherPullRequestBranch}:${filePath}`
+    `git show refs/remotes/origin/conflictbot_tmp_${otherPullRequestBranch}:${filePath}`
   ).toString();
 
   const linesFromNormalFile = fileContentWithoutConflicts.split("\n");
@@ -10461,8 +10467,7 @@ function extractConflictingLineNumbers(otherPullRequestBranch, filePath) {
 function cleanup() {
   try {
     const pullRequest = github.context.payload.pull_request;
-
-    execSync(`git update-ref -d refs/remotes/origin/tmp_${pullRequest.number}`);
+    execSync(`git update-ref -d refs/remotes/origin/conflictbot_tmp_${pullRequest.branch}`);
   } catch (e) {
     console.error(`Error during cleanup: ${error.message}`);
     throw error;

--- a/index.js
+++ b/index.js
@@ -3,53 +3,19 @@ const github = require("@actions/github");
 const { execSync } = require("child_process");
 const readFileSync = require("fs").readFileSync;
 
-const { debug, formatLineNumbers } = require("./index.utils");
-const excludedFiles = ["go.mod", "go.sum", "vendor/"];
-
-class Variables {
-  static _instance = null;
-  _variables = {};
-
-  constructor() {
-    if (Variables._instance) {
-      return Variables._instance;
-    }
-
-    const token = core.getInput("github-token", { required: true });
-
-    const quietInput = core.getInput("quiet", { required: false }) || "false";
-    const quiet = ["true", "yes", "on"].includes(quietInput.toLowerCase());
-
-    const pullRequest = github.context.payload.pull_request;
-
-    this._variables = {
-      mainBranch: core.getInput("main-branch", { required: false }) || "main",
-      octokit: github.getOctokit(token),
-      pullRequestAuthor: pullRequest.user.login,
-      pullRequestBranch: pullRequest.head.ref,
-      pullRequestNumber: pullRequest.number,
-      quiet,
-      repo: github.context.repo,
-      token,
-      isFork: pullRequest.head.repo.fork,
-      headRepo: pullRequest.head.repo.full_name,
-    };
-
-    Variables._instance = this;
-  }
-
-  set(name, value) {
-    this._variables[name] = value;
-  }
-
-  get(name) {
-    return this._variables[name];
-  }
-}
+const { debug } = require("./index.utils");
+const {
+  Variables,
+  getOpenPullRequests,
+  getChangedFiles,
+  requestReviews,
+  requestReviewsInConflictingPRs,
+  createConflictComment,
+} = require("./index.requests");
 
 async function main() {
   if (github.context.payload.pull_request.draft) {
-    debug(`Not running any checks because this pull request is a draft.`)
+    debug(`Not running any checks because this pull request is a draft`)
     return
   }
 
@@ -147,68 +113,6 @@ async function getConflictArrayData() {
   return conflictArray;
 }
 
-function cleanup() {
-  try {
-    const pullRequest = github.context.payload.pull_request;
-
-    execSync(`git update-ref -d refs/remotes/origin/tmp_${pullRequest.number}`);
-  } catch (e) {
-    console.error(`Error during cleanup: ${error.message}`);
-    throw error;
-  }
-}
-
-async function getOpenPullRequests() {
-  const variables = new Variables();
-  const octokit = variables.get("octokit");
-  const repo = variables.get("repo");
-
-  try {
-    const allPullRequests = []
-    let page = 1;
-    while (true) {
-      const { data: pullRequests } = await octokit.rest.pulls.list({
-        owner: repo.owner,
-        repo: repo.repo,
-        state: "open",
-        per_page: 100,
-        page: page,
-      });
-
-      if (pullRequests.length > 0) {
-        allPullRequests.push(...pullRequests);
-        page++;
-      } else {
-        break
-      }
-    }
-
-    const openPullRequests = []
-
-    for (const pr of allPullRequests) {
-      if (pr.draft) {
-        continue
-      }
-
-      openPullRequests.push({
-        number: pr.number,
-        author: pr.user.login,
-        branch: pr.head.ref,
-        title: pr.title,
-        reviewers: await getAllReviewers(pr.number),
-        isFork: pr.head.repo.fork,
-        repo: pr.head.repo.full_name,
-      })
-    }
-
-    return openPullRequests;
-  } catch (error) {
-    console.error(`Error fetching open pull requests: ${error.message}`);
-    throw error;
-  }
-}
-
-
 async function checkForConflicts(otherPullRequest) {
   const variables = new Variables();
   const pullRequestBranch = variables.get("pullRequestBranch");
@@ -234,33 +138,6 @@ async function checkForConflicts(otherPullRequest) {
   const conflictData = await attemptMerge(otherPullRequest);
 
   return conflictData;
-}
-
-async function getChangedFiles(anyPullRequestNumber) {
-  const variables = new Variables();
-  const octokit = variables.get("octokit");
-  const repo = variables.get("repo");
-
-  const allFiles = []
-  let page = 1;
-  while (true) {
-    const { data: files } = await octokit.rest.pulls.listFiles({
-      owner: repo.owner,
-      repo: repo.repo,
-      pull_number: anyPullRequestNumber,
-      per_page: 100,
-      page: page,
-    });
-
-    if (files.length > 0) {
-      allFiles.push(...files);
-      page++;
-    } else {
-      break
-    }
-  }
-
-  return allFiles.map((file) => file.filename).filter((file) => !ignoreFile(file));
 }
 
 async function attemptMerge(otherPullRequest) {
@@ -396,174 +273,15 @@ function extractConflictingLineNumbers(otherPullRequestBranch, filePath) {
   return conflictLines;
 }
 
-async function createConflictComment(conflictArray) {
-  const variables = new Variables();
-  const octokit = variables.get("octokit");
-  const pullRequestNumber = variables.get("pullRequestNumber");
-  const repo = variables.get("repo");
-
+function cleanup() {
   try {
-    let totalFilesWithConflicts = 0;
-    let conflictMessage = "";
+    const pullRequest = github.context.payload.pull_request;
 
-    for (const data of conflictArray) {
-      totalFilesWithConflicts += Object.keys(data.conflictData).length;
-      conflictMessage += `<details>\n`;
-      conflictMessage += `  <summary>${data.title} (#${data.number}) by @${data.author}</summary>\n`;
-
-      for (const [fileName, lineNumbers] of Object.entries(data.conflictData)) {
-        const allFiles = []
-        let page = 1;
-        while (true) {
-          const { data: files } = await octokit.rest.pulls.listFiles({
-            owner: repo.owner,
-            repo: repo.repo,
-            pull_number: data.number,
-            per_page: 100,
-            page: page,
-          });
-
-          if (files.length > 0) {
-            allFiles.push(...files);
-            page++;
-          } else {
-            break
-          }
-        }
-
-        const blobUrl = allFiles.find(
-          (file) => file.filename === fileName
-        ).blob_url;
-
-        conflictMessage += `\u00A0\u00A0\u00A0 <a href="${blobUrl}">${fileName}</a> \u2015 ${formatLineNumbers(
-          lineNumbers
-        )}<br />`;
-      }
-
-      conflictMessage += `</details>\n\n`;
-    }
-
-    const prs = conflictArray.length === 1 ? "PR" : "PRs";
-    const files = totalFilesWithConflicts === 1 ? "file" : "files";
-
-    conflictMessage =
-      `Conflicts detected in ${totalFilesWithConflicts} ${files} across ${conflictArray.length} ${prs}\n\n` +
-      conflictMessage;
-
-    await octokit.rest.issues.createComment({
-      owner: repo.owner,
-      repo: repo.repo,
-      issue_number: pullRequestNumber,
-      body: conflictMessage,
-    });
-  } catch (error) {
-    console.error(`Error creating conflict comment: ${error.message}`);
+    execSync(`git update-ref -d refs/remotes/origin/tmp_${pullRequest.number}`);
+  } catch (e) {
+    console.error(`Error during cleanup: ${error.message}`);
     throw error;
   }
-}
-
-async function requestReviews(conflictArray) {
-  const variables = new Variables();
-  const octokit = variables.get("octokit");
-  const pullRequestAuthor = variables.get("pullRequestAuthor");
-  const pullRequestNumber = variables.get("pullRequestNumber");
-  const repo = variables.get("repo");
-
-  try {
-    const existing_reviewers = await getAllReviewers(pullRequestNumber)
-    const reviewers = [
-      ...new Set(
-        conflictArray
-          .map((conflict) => conflict.author)
-          .filter((author) => author !== pullRequestAuthor && !existing_reviewers.has(author))
-      ),
-    ];
-
-    if (reviewers.length > 0) {
-      debug(`Requesting reviews from ${reviewers.join(", ")}`);
-
-      await octokit.rest.pulls.requestReviewers({
-        owner: repo.owner,
-        repo: repo.repo,
-        pull_number: pullRequestNumber,
-        reviewers: reviewers,
-      });
-    } else {
-      debug(`No new reviews to request.`)
-    }
-
-    return reviewers.length
-  } catch (error) {
-    console.error(`Error requesting reviews: ${error.message}`);
-    throw error;
-  }
-}
-
-async function requestReviewsInConflictingPRs(conflictArray) {
-  const variables = new Variables();
-  const octokit = variables.get("octokit");
-  const pullRequestAuthor = variables.get("pullRequestAuthor");
-  const repo = variables.get("repo");
-
-  let requestedReviews = 0;
-  try {
-    for (const conflict of conflictArray) {
-      if (conflict.author !== pullRequestAuthor && !conflict.reviewers.has(pullRequestAuthor)) {
-        debug(
-          `Requesting review from ${pullRequestAuthor} in #${conflict.number}`
-        );
-
-        await octokit.rest.pulls.requestReviewers({
-          owner: repo.owner,
-          repo: repo.repo,
-          pull_number: conflict.number,
-          reviewers: [pullRequestAuthor],
-        });
-        requestedReviews++;
-      }
-    }
-
-    return requestedReviews;
-  } catch (error) {
-    console.error(
-      `Error requesting reviews in conflicting PRs: ${error.message}`
-    );
-    throw error;
-  }
-}
-
-// This function gets all reviewers on the conflicting pull requests.
-// The reviewers include requested reviewers and those who have left a review.
-async function getAllReviewers(pr_number) {
-  const variables = new Variables();
-  const octokit = variables.get("octokit");
-  const repo = variables.get("repo");
-
-  const { data: reviews } = await octokit.rest.pulls.listReviews({
-    owner: repo.owner,
-    repo: repo.repo,
-    pull_number: pr_number,
-  });
-
-  const { data: requested_reviewers } = await octokit.rest.pulls.listRequestedReviewers({
-    owner: repo.owner,
-    repo: repo.repo,
-    pull_number: pr_number,
-  });
-
-  const viewed_reviewers = reviews.map((r) => r.user.login)
-  const req_reviewers = requested_reviewers.users.map((r) => r.login)
-
-  return new Set (viewed_reviewers.concat(req_reviewers))
-}
-
-function ignoreFile(filename) {
-    for (const excluded of excludedFiles) {
-      if (filename.includes(excluded)) {
-        return true
-      }
-    }
-    return false
 }
 
 main();

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ async function getConflictArrayData() {
         title: otherPullRequest.title,
         reviewers: otherPullRequest.reviewers,
       });
-    } 
+    }
   }
 
   return conflictArray;
@@ -189,7 +189,7 @@ async function attemptMerge(otherPullRequest) {
         `git merge refs/remotes/origin/conflictbot_tmp_${pullRequestBranch} --no-commit --no-ff`
       );
 
-      debug(`${otherPullRequest.branch} merge successful. No conflicts found.`);
+      debug(`${otherPullRequest.branch} merge successful. No conflicts found`);
     } catch (mergeError) {
       const stdoutStr = mergeError.stdout.toString();
       if (stdoutStr.includes("Automatic merge failed")) {

--- a/index.requests.js
+++ b/index.requests.js
@@ -1,0 +1,302 @@
+const core = require("@actions/core");
+const github = require("@actions/github");
+
+const { debug, formatLineNumbers } = require("./index.utils");
+const excludedFiles = ["go.mod", "go.sum", "vendor/"];
+
+class Variables {
+  static _instance = null;
+  _variables = {};
+
+  constructor() {
+    if (Variables._instance) {
+      return Variables._instance;
+    }
+
+    const token = core.getInput("github-token", { required: true });
+
+    const quietInput = core.getInput("quiet", { required: false }) || "false";
+    const quiet = ["true", "yes", "on"].includes(quietInput.toLowerCase());
+
+    const pullRequest = github.context.payload.pull_request;
+
+    this._variables = {
+      mainBranch: core.getInput("main-branch", { required: false }) || "main",
+      octokit: github.getOctokit(token),
+      pullRequestAuthor: pullRequest.user.login,
+      pullRequestBranch: pullRequest.head.ref,
+      pullRequestNumber: pullRequest.number,
+      quiet,
+      repo: github.context.repo,
+      token,
+      isFork: pullRequest.head.repo.fork,
+      headRepo: pullRequest.head.repo.full_name,
+    };
+
+    Variables._instance = this;
+  }
+
+  set(name, value) {
+    this._variables[name] = value;
+  }
+
+  get(name) {
+    return this._variables[name];
+  }
+}
+
+async function getOpenPullRequests() {
+  const variables = new Variables();
+  const octokit = variables.get("octokit");
+  const repo = variables.get("repo");
+
+  try {
+    const allPullRequests = []
+    let page = 1;
+    while (true) {
+      const { data: pullRequests } = await octokit.rest.pulls.list({
+        owner: repo.owner,
+        repo: repo.repo,
+        state: "open",
+        per_page: 100,
+        page: page,
+      });
+
+      if (pullRequests.length > 0) {
+        allPullRequests.push(...pullRequests);
+        page++;
+      } else {
+        break
+      }
+    }
+
+    const openPullRequests = []
+
+    for (const pr of allPullRequests) {
+      if (pr.draft) {
+        continue
+      }
+
+      openPullRequests.push({
+        number: pr.number,
+        author: pr.user.login,
+        branch: pr.head.ref,
+        title: pr.title,
+        reviewers: await getAllReviewers(pr.number),
+        isFork: pr.head.repo.fork,
+        repo: pr.head.repo.full_name,
+      })
+    }
+
+    return openPullRequests;
+  } catch (error) {
+    console.error(`Error fetching open pull requests: ${error.message}`);
+    throw error;
+  }
+}
+
+async function getChangedFiles(anyPullRequestNumber) {
+  const variables = new Variables();
+  const octokit = variables.get("octokit");
+  const repo = variables.get("repo");
+
+  const allFiles = []
+  let page = 1;
+  while (true) {
+    const { data: files } = await octokit.rest.pulls.listFiles({
+      owner: repo.owner,
+      repo: repo.repo,
+      pull_number: anyPullRequestNumber,
+      per_page: 100,
+      page: page,
+    });
+
+    if (files.length > 0) {
+      allFiles.push(...files);
+      page++;
+    } else {
+      break
+    }
+  }
+
+  return allFiles.map((file) => file.filename).filter((file) => !ignoreFile(file));
+}
+
+function ignoreFile(filename) {
+    for (const excluded of excludedFiles) {
+      if (filename.includes(excluded)) {
+        return true
+      }
+    }
+    return false
+}
+
+async function requestReviews(conflictArray) {
+  const variables = new Variables();
+  const octokit = variables.get("octokit");
+  const pullRequestAuthor = variables.get("pullRequestAuthor");
+  const pullRequestNumber = variables.get("pullRequestNumber");
+  const repo = variables.get("repo");
+
+  try {
+    const existing_reviewers = await getAllReviewers(pullRequestNumber)
+    const reviewers = [
+      ...new Set(
+        conflictArray
+          .map((conflict) => conflict.author)
+          .filter((author) => author !== pullRequestAuthor && !existing_reviewers.has(author))
+      ),
+    ];
+
+    if (reviewers.length > 0) {
+      debug(`Requesting reviews from ${reviewers.join(", ")}`);
+
+      await octokit.rest.pulls.requestReviewers({
+        owner: repo.owner,
+        repo: repo.repo,
+        pull_number: pullRequestNumber,
+        reviewers: reviewers,
+      });
+    } else {
+      debug(`No new reviews to request.`)
+    }
+
+    return reviewers.length
+  } catch (error) {
+    console.error(`Error requesting reviews: ${error.message}`);
+    throw error;
+  }
+}
+
+async function requestReviewsInConflictingPRs(conflictArray) {
+  const variables = new Variables();
+  const octokit = variables.get("octokit");
+  const pullRequestAuthor = variables.get("pullRequestAuthor");
+  const repo = variables.get("repo");
+
+  let requestedReviews = 0;
+  try {
+    for (const conflict of conflictArray) {
+      if (conflict.author !== pullRequestAuthor && !conflict.reviewers.has(pullRequestAuthor)) {
+        debug(
+          `Requesting review from ${pullRequestAuthor} in #${conflict.number}`
+        );
+
+        await octokit.rest.pulls.requestReviewers({
+          owner: repo.owner,
+          repo: repo.repo,
+          pull_number: conflict.number,
+          reviewers: [pullRequestAuthor],
+        });
+        requestedReviews++;
+      }
+    }
+
+    return requestedReviews;
+  } catch (error) {
+    console.error(
+      `Error requesting reviews in conflicting PRs: ${error.message}`
+    );
+    throw error;
+  }
+}
+
+// This function gets all reviewers on the conflicting pull requests.
+// The reviewers include requested reviewers and those who have left a review.
+async function getAllReviewers(pr_number) {
+  const variables = new Variables();
+  const octokit = variables.get("octokit");
+  const repo = variables.get("repo");
+
+  const { data: reviews } = await octokit.rest.pulls.listReviews({
+    owner: repo.owner,
+    repo: repo.repo,
+    pull_number: pr_number,
+  });
+
+  const { data: requested_reviewers } = await octokit.rest.pulls.listRequestedReviewers({
+    owner: repo.owner,
+    repo: repo.repo,
+    pull_number: pr_number,
+  });
+
+  const viewed_reviewers = reviews.map((r) => r.user.login)
+  const req_reviewers = requested_reviewers.users.map((r) => r.login)
+
+  return new Set (viewed_reviewers.concat(req_reviewers))
+}
+
+async function createConflictComment(conflictArray) {
+  const variables = new Variables();
+  const octokit = variables.get("octokit");
+  const pullRequestNumber = variables.get("pullRequestNumber");
+  const repo = variables.get("repo");
+
+  try {
+    let totalFilesWithConflicts = 0;
+    let conflictMessage = "";
+
+    for (const data of conflictArray) {
+      totalFilesWithConflicts += Object.keys(data.conflictData).length;
+      conflictMessage += `<details>\n`;
+      conflictMessage += `  <summary>${data.title} (#${data.number}) by @${data.author}</summary>\n`;
+
+      for (const [fileName, lineNumbers] of Object.entries(data.conflictData)) {
+        const allFiles = []
+        let page = 1;
+        while (true) {
+          const { data: files } = await octokit.rest.pulls.listFiles({
+            owner: repo.owner,
+            repo: repo.repo,
+            pull_number: data.number,
+            per_page: 100,
+            page: page,
+          });
+
+          if (files.length > 0) {
+            allFiles.push(...files);
+            page++;
+          } else {
+            break
+          }
+        }
+
+        const blobUrl = allFiles.find(
+          (file) => file.filename === fileName
+        ).blob_url;
+
+        conflictMessage += `\u00A0\u00A0\u00A0 <a href="${blobUrl}">${fileName}</a> \u2015 ${formatLineNumbers(
+          lineNumbers
+        )}<br />`;
+      }
+
+      conflictMessage += `</details>\n\n`;
+    }
+
+    const prs = conflictArray.length === 1 ? "PR" : "PRs";
+    const files = totalFilesWithConflicts === 1 ? "file" : "files";
+
+    conflictMessage =
+      `Conflicts detected in ${totalFilesWithConflicts} ${files} across ${conflictArray.length} ${prs}\n\n` +
+      conflictMessage;
+
+    await octokit.rest.issues.createComment({
+      owner: repo.owner,
+      repo: repo.repo,
+      issue_number: pullRequestNumber,
+      body: conflictMessage,
+    });
+  } catch (error) {
+    console.error(`Error creating conflict comment: ${error.message}`);
+    throw error;
+  }
+}
+
+module.exports = {
+  Variables,
+  getOpenPullRequests,
+  getChangedFiles,
+  requestReviews,
+  requestReviewsInConflictingPRs,
+  createConflictComment
+};

--- a/index.requests.js
+++ b/index.requests.js
@@ -30,7 +30,7 @@ class Variables {
       repo: github.context.repo,
       token,
       isFork: pullRequest.head.repo.fork,
-      headRepo: pullRequest.head.repo.full_name,
+      pullRequestHeadUrl: pullRequest.head.repo.clone_url,
     };
 
     Variables._instance = this;
@@ -84,7 +84,7 @@ async function getOpenPullRequests() {
         title: pr.title,
         reviewers: await getAllReviewers(pr.number),
         isFork: pr.head.repo.fork,
-        repo: pr.head.repo.full_name,
+        pullRequestHeadUrl: pr.head.repo.clone_url,
       })
     }
 


### PR DESCRIPTION
This change mainly adds support for PRs from forked repos. 
I did this by adding forked repos as remotes named after their owner (PR author) and fetching their branches to `origin/conflictbot_tmp_`. These tmp branches get cleaned up after each merge attempt so adding them to origin does not cause conflicts.

Some other minor changes:
- Moved the functions related to making api requests to `index.requests.js` to break up `index.js`.
- Added additional logging.
- Change the temporary branch prefix from `tmp` to `conflictbot_tmp`.
- Bug fix: Paginate to retrieve PR files.
- Update to node20 since node12 is deprecated.
- Added periods at the end of comments.

I manually tested this against my own repo. Action runs at: https://github.com/jtcovan/test_bots/actions